### PR TITLE
Improving installer and restoring init.d, fixes #73

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ archives:
       - README.md
       - LICENSE
       - CHANGELOG.md
-      - webexec.service.tmpl
+      - webexecd.sh
       - replace_n_launch.sh
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ archives:
       - LICENSE
       - CHANGELOG.md
       - webexecd.sh
+      - webexec.service.tmpl
       - replace_n_launch.sh
 
 

--- a/get/install.bash
+++ b/get/install.bash
@@ -12,7 +12,7 @@ LATEST_VERSION="0.15.3"
 echo "Installing webexec version " $LATEST_VERSION
          
 ARCH="$(uname -m | tr [:upper:] [:lower:])" 
-if [ "$ARCH" = x86_64* ]; then
+if [[ "$ARCH" = x86_64* ]]; then
     if [[ "$(uname -a)" = *ARM64* ]]; then
         ARCH='arm64'
     else

--- a/get/install.bash
+++ b/get/install.bash
@@ -2,37 +2,74 @@
 # webexec installation script
 #
 # This script is meant for quick & easy install via:
+#
+#   $ curl -L https://get.webexec.sh -o get-webexec.sh | bash get-webexec.sh
 set -x
-
-#   $ curl -L https://get.webexec.sh | bash
 SCRIPT_COMMIT_SHA=UNKNOWN
 LATEST_VERSION="0.15.3"
 
 # The latest release is currently hard-coded.
-echo "Installing " $LATEST_VERSION "version"
+echo "Installing webexec version " $LATEST_VERSION
          
-ARCH="$(uname -m)"  # -i is only linux, -m is linux and apple
-if [[ "$ARCH" = x86_64* ]]; then
+ARCH="$(uname -m | tr [:upper:] [:lower:])" 
+if [ "$ARCH" = x86_64* ]; then
     if [[ "$(uname -a)" = *ARM64* ]]; then
         ARCH='arm64'
     else
         ARCH="amd64"
     fi
-elif [[ "$ARCH" = i*86 ]]; then
+elif [ "$ARCH" = i386 ]; then
     ARCH='386'
 elif [[ "$ARCH" = armv6* ]]; then
     ARCH='armv6'
 elif [[ "$ARCH" = armv7* ]]; then
     ARCH='armv7'
-elif [[ "$ARCH" = aARCH64 ]]; then
+elif [[ "$ARCH" = aarch64 ]]; then
     ARCH='armv7'
 else
+    echo "Sorry, unsupported architecture $ARCH"
+    echo "Try using: `go install github.com/tuzig/webexec` to install from source"
     exit 1
 fi
 
+DEBUG=${DEBUG:-}
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--debug)
+			DEBUG=1
+			;;
+		--*)
+			echo "Illegal option $1"
+			;;
+	esac
+	shift $(( $# > 0 ? 1 : 0 ))
+done
+
+debug() {
+	if [ -z "$DEBUG" ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+command_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+get_distribution() {
+	lsb_dist=""
+	# Every system that we officially support has /etc/os-release
+	if [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
+	# Returning an empty string here should be alright since the
+	# case statements don't act unless you provide an actual value
+	echo "$lsb_dist"
+}
 
 init_vars() {
-	BIN="${WEBEXEC_BIN:/usr/local/bin}"
+	BIN="${WEBEXEC_BIN:/usr/debug/bin}"
 
 	DAEMON=webexec
 	SYSTEMD=
@@ -78,7 +115,7 @@ checks() {
 get_n_extract() {
 	case "$(uname)" in
 	Darwin)
-        if command -v go &> /dev/null; then
+        if command_exists go; then
             go install github.com/tuzig/webexec@v$LATEST_VERSION
             webexec init
             webexec start
@@ -100,24 +137,53 @@ get_n_extract() {
         
 		;;
 	Linux)
-        STATIC_RELEASE_URL="https://github.com/tuzig/webexec/releases/download/v$LATEST_VERSION/webexec_${LATEST_VERSION}_$(uname -s | tr '[:upper:]' '[:lower:]')_$ARCH.tar.gz"
-       curl -sL "$STATIC_RELEASE_URL" | tar zx --strip-components=1
-       ./webexec init
+        BALL_NAME="webexec_${LATEST_VERSION}_$(uname -s | tr [:upper:] [:lower:])_$ARCH.tar.gz"
+        STATIC_RELEASE_URL="https://github.com/tuzig/webexec/releases/download/v$LATEST_VERSION/$BALL_NAME"
+        curl -sL "$STATIC_RELEASE_URL" -o $1/$BALL_NAME
+        tar zx --strip-components=1 -C $1 < $1/$BALL_NAME 
 	esac
 }
+
 do_install() {
 	init_vars
 	checks
 
-	tmp=$(mktemp -d)
+	sh_c='sh -c'
+	if [ "$user" != 'root' ]; then
+		if command_exists sudo; then
+			sh_c='sudo -E sh -c'
+		elif command_exists su; then
+			sh_c='su -c'
+		else
+			cat >&2 <<-'EOF'
+			Error: this installer needs the ability to run commands as root.
+			We are unable to find either "sudo" or "su" available to make this happen.
+			EOF
+			exit 1
+		fi
+	fi
+	lsb_dist=$( get_distribution )
+	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+	# Run setup for each distro accordingly
+	case "$lsb_dist" in
+		ubuntu|debian|raspbian)
+			pre_reqs="curl"
+            $sh_c 'apt-get update -qq >/dev/null'
+            $sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+			;;
+    esac
 
-    echo "Created temp dir: $tmp"
-    cd $tmp
-    get_n_extract
+    tmp=$(mktemp -d)
+    echo "Created temp dir at $tmp"
+    get_n_extract $tmp
+    $tmp/webexec init
     # TODO: fixed launchd
-    if [[ "$(uname)" = Linux ]]; then
-        echo "==> We need su power to add webexec's binary and service"
-        sudo nohup bash replace_n_launch.sh $USER $HOME
+    if [ "$(uname)" = Linux ]; then
+        if debug; then
+            $sh_c "nohup bash replace_n_launch.sh $USER $HOME"
+        else
+            $sh_c "nohup bash $tmp/replace_n_launch.sh $USER $HOME"
+        fi
     fi
 }
 do_install "$@"

--- a/get/install.bash
+++ b/get/install.bash
@@ -164,7 +164,7 @@ do_install() {
     $wd/webexec init
     # TODO: fixed launchd
     if [ "$(uname)" = Linux ]; then
-		$sh_c "nohup bash $wd/replace_n_launch.sh $USER $HOME"
+		$sh_c "nohup bash cd $wd && replace_n_launch.sh $USER $HOME"
     fi
 }
 do_install "$@"

--- a/get/install.bash
+++ b/get/install.bash
@@ -156,15 +156,13 @@ do_install() {
     tmp=$(mktemp -d)
     echo "Created temp dir at $tmp"
     get_n_extract $tmp
-	if debug; then
-		wd=.
-	else
-		wd=$tmp
+	if ! debug; then
+        cd $tmp
 	fi
-    $wd/webexec init
+    ./webexec init
     # TODO: fixed launchd
     if [ "$(uname)" = Linux ]; then
-		$sh_c "nohup bash cd $wd && replace_n_launch.sh $USER $HOME"
+		$sh_c "nohup bash ./replace_n_launch.sh $USER $HOME"
     fi
 }
 do_install "$@"

--- a/get/install.bash
+++ b/get/install.bash
@@ -3,7 +3,8 @@
 #
 # This script is meant for quick & easy install via:
 #
-#   $ curl -L https://get.webexec.sh -o get-webexec.sh | bash get-webexec.sh
+#   $ curl -L https://get.webexec.sh -o get-webexec.sh && bash get-webexec.sh
+#
 set -x
 SCRIPT_COMMIT_SHA=UNKNOWN
 LATEST_VERSION="0.15.3"
@@ -68,16 +69,6 @@ get_distribution() {
 	echo "$lsb_dist"
 }
 
-init_vars() {
-	BIN="${WEBEXEC_BIN:/usr/debug/bin}"
-
-	DAEMON=webexec
-	SYSTEMD=
-	if systemctl --user daemon-reload >/dev/null 2>&1; then
-		SYSTEMD=1
-	fi
-}
-
 checks() {
 	# OS verification: Linux only, point osx/win to helpful locations
 	case "$(uname)" in
@@ -98,17 +89,6 @@ checks() {
     if [ ! -w "$HOME" ]; then
         >&2 echo "Aborting because HOME (\"$HOME\") is not writable"; exit 1
     fi
-
-	# Validate XDG_RUNTIME_DIR
-	if [ ! -w "$XDG_RUNTIME_DIR" ]; then
-		if [ -n "$SYSTEMD" ]; then
-			>&2 echo "Aborting because systemd was detected but XDG_RUNTIME_DIR (\"$XDG_RUNTIME_DIR\") does not exist or is not writable"
-			>&2 echo "Hint: this could happen if you changed users with 'su' or 'sudo'. To work around this:"
-			>&2 echo "- try again by first running with root privileges 'loginctl enable-linger <user>' where <user> is the unprivileged user and export XDG_RUNTIME_DIR to the value of RuntimePath as shown by 'loginctl show-user <user>'"
-			>&2 echo "- or simply log back in as the desired unprivileged user (ssh works for remote machines)"
-			exit 1
-		fi
-	fi
 
 }
 
@@ -145,7 +125,6 @@ get_n_extract() {
 }
 
 do_install() {
-	init_vars
 	checks
 
 	sh_c='sh -c'

--- a/get/install.bash
+++ b/get/install.bash
@@ -14,6 +14,7 @@ echo "Installing webexec version " $LATEST_VERSION
          
 ARCH="$(uname -m | tr [:upper:] [:lower:])" 
 if [[ "$ARCH" = x86_64* ]]; then
+    # and now for some M1 fun
     if [[ "$(uname -a)" = *ARM64* ]]; then
         ARCH='arm64'
     else

--- a/get/install.bash
+++ b/get/install.bash
@@ -167,23 +167,25 @@ do_install() {
 	# Run setup for each distro accordingly
 	case "$lsb_dist" in
 		ubuntu|debian|raspbian)
-			pre_reqs="curl"
-            $sh_c 'apt-get update -qq >/dev/null'
-            $sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+			if ! command_exists curl; then
+				$sh_c 'apt-get update -qq >/dev/null'
+				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+			fi
 			;;
     esac
 
     tmp=$(mktemp -d)
     echo "Created temp dir at $tmp"
     get_n_extract $tmp
-    $tmp/webexec init
+	if debug; then
+		wd=.
+	else
+		wd=$tmp
+	fi
+    $wd/webexec init
     # TODO: fixed launchd
     if [ "$(uname)" = Linux ]; then
-        if debug; then
-            $sh_c "nohup bash replace_n_launch.sh $USER $HOME"
-        else
-            $sh_c "nohup bash $tmp/replace_n_launch.sh $USER $HOME"
-        fi
+		$sh_c "nohup bash $wd/replace_n_launch.sh $USER $HOME"
     fi
 }
 do_install "$@"

--- a/get/install.bash
+++ b/get/install.bash
@@ -161,7 +161,6 @@ do_install() {
         cd $tmp
 	fi
     ./webexec init
-    # TODO: fixed launchd
     if [ "$(uname)" = Linux ]; then
 		$sh_c "nohup bash ./replace_n_launch.sh $USER $HOME"
     fi

--- a/replace_n_launch.sh
+++ b/replace_n_launch.sh
@@ -18,8 +18,7 @@ Linux)
         /etc/init.d/webexec stop
     fi
     cp webexec /usr/local/bin
-    ECHO_CONF="echo USER=$(whoami)"
-    sh -c "$ECHO_CONF >/etc/webexec"
+    sh -c "echo USER=$1 >/etc/webexec"
     cp webexecd.sh /etc/init.d/webexec
     chown root:root /etc/init.d/webexec
     update-rc.d webexec defaults

--- a/replace_n_launch.sh
+++ b/replace_n_launch.sh
@@ -14,12 +14,15 @@ Darwin)
     launchctl load "/Library/LaunchDaemons/sh.webexec.daemon.plist"
     ;;
 Linux)
-    systemctl stop webexec.service
+    if [ -x /etc/init.d/webexec ]; then
+        /etc/init.d/webexec stop
+    fi
     cp webexec /usr/local/bin
-    USER="$1" HOME="$2" envsubst < webexec.service.tmpl > /etc/systemd/system/webexec.service
-    chown root:root /etc/systemd/system/webexec.service
-    systemctl daemon-reload
-    systemctl enable webexec.service
-    systemctl start webexec.service
+    ECHO_CONF="echo USER=$(whoami)"
+    sh -c "$ECHO_CONF >/etc/webexec"
+    cp webexecd.sh /etc/init.d/webexec
+    chown root:root /etc/init.d/webexec
+    update-rc.d webexec defaults
+    /etc/init.d/webexec start 
     ;;
 esac

--- a/replace_n_launch.sh
+++ b/replace_n_launch.sh
@@ -27,16 +27,16 @@ Linux)
         rm /etc/systemd/system/webexec.service
     fi
     cp webexec /usr/local/bin
-    sh -c "echo USER=$1 >/etc/webexec"
     if command_exists systemctl; then
         cp webexec.service.tmpl webexec.service
-        sed -i "s/\$USER/$1/; s/\$HOME/$2" webexec.service
+        sed -i "s/\$USER/$1/g; s?\$HOME?$2?g" webexec.service
         chown root:root webexec.service
         mv webexec.service /etc/systemd/system/webexec.service
         systemctl daemon-reload
         systemctl enable webexec.service
         systemctl start webexec.service
     else
+        sh -c "echo USER=$1 >/etc/webexec"
         cp webexecd.sh /etc/init.d/webexec
         chown root:root /etc/init.d/webexec
         update-rc.d webexec defaults

--- a/replace_n_launch.sh
+++ b/replace_n_launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # this should be run as root
 set -x
 
@@ -16,6 +16,10 @@ Darwin)
 Linux)
     if [ -x /etc/init.d/webexec ]; then
         /etc/init.d/webexec stop
+    fi
+    if [ -f /etc/systemd/system/webexec.service ]; then
+        systemctl stop webexec.service
+        rm /etc/systemd/system/webexec.service
     fi
     cp webexec /usr/local/bin
     sh -c "echo USER=$1 >/etc/webexec"

--- a/webexec.go
+++ b/webexec.go
@@ -351,7 +351,10 @@ func initCMD(c *cli.Context) error {
 	homePath := ConfPath("")
 	_, err := os.Stat(homePath)
 	if os.IsNotExist(err) {
-		os.Mkdir(homePath, 0755)
+		err = os.MkdirAll(homePath, 0755)
+		if err != nil {
+			return err
+		}
 		fmt.Printf("Created %q directory\n", homePath)
 	} else {
 		return fmt.Errorf(


### PR DESCRIPTION
Also added a --debug flag that should be run from the project's root. With debug the script download the tar ball and expends it but runs the binary and scripts from the current dir.