### PR TITLE
Added support for WSL2 by checking for nonfunctioning systemctl

### DIFF
--- a/replace_n_launch.sh
+++ b/replace_n_launch.sh
@@ -27,15 +27,21 @@ Linux)
         rm /etc/systemd/system/webexec.service
     fi
     cp webexec /usr/local/bin
+    systemctl=0
     if command_exists systemctl; then
-        cp webexec.service.tmpl webexec.service
-        sed -i "s/\$USER/$1/g; s?\$HOME?$2?g" webexec.service
-        chown root:root webexec.service
-        mv webexec.service /etc/systemd/system/webexec.service
-        systemctl daemon-reload
-        systemctl enable webexec.service
-        systemctl start webexec.service
-    else
+        systemctl >/dev/null
+        if [ $? -eq 0 ]; then
+            cp webexec.service.tmpl webexec.service
+            sed -i "s/\$USER/$1/g; s?\$HOME?$2?g" webexec.service
+            chown root:root webexec.service
+            mv webexec.service /etc/systemd/system/webexec.service
+            systemctl daemon-reload
+            systemctl enable webexec.service
+            systemctl start webexec.service
+            systemctl=1
+        fi
+    fi
+    if [ $systemctl -eq 0 ]; then
         sh -c "echo USER=$1 >/etc/webexec"
         cp webexecd.sh /etc/init.d/webexec
         chown root:root /etc/init.d/webexec


### PR DESCRIPTION
For WSL2 it is not enough to check for the existence of the `systemctl` command, as Ubuntu on WSL2 has the `systemctl` executable, but the output is:
```
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```
We check for WSL2 by making sure the error code returned by `systemctl` is 0.
